### PR TITLE
Update docs with a note about Heroku Pipelines and promotions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ $ git push https://git.heroku.com/example-2.git HEAD:master
 
 When example-1 builds, it'll copy Procfile into /app/Procfile, and when example-2 builds, it'll copy backend/Procfile to /app/Procfile. For example-2, the process types available for you to scale up will be the ones referenced (originally) in backend/Procfile.
 
+# Pipelines
+
+Only **builds** will set the proper Procfile. If you use [Heroku Pipelines](https://devcenter.heroku.com/articles/pipelines), then promoting a slug downstream will not trigger a build, and therefore will not look at the environment variable and act accordingly. Make sure that the proper Procfile is referenced all the way upstream to the first stage that builds.
+
 # Authors
 
 Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com>


### PR DESCRIPTION
This bit me recently when trying to determine why our production stage wasn't using the proper Procfile. Only builds result in the environment variable being referenced, which makes sense but wasn't immediately obvious to me. This note, added to the README, may help others in the future.