### PR TITLE
Copy app.json if it exists

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 indent() {
-    sed -u 's/^/      /'
+    sed -u 's/^/       /'
 }
 
 BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -8,14 +8,14 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-PROCFILE=$(cat ${ENV_DIR}/PROCFILE)
+PROCFILE=$(cat "${ENV_DIR}/PROCFILE")
 
 if [[ -z "${PROCFILE}" ]]; then
     echo "PROCFILE was not set. Aborting" | indent
     exit 1
 fi
 
-cp ${BUILD_DIR}/${PROCFILE} ${BUILD_DIR}/Procfile
+cp "${BUILD_DIR}/${PROCFILE}" "${BUILD_DIR}/Procfile"
 
 if ! [ $? ]; then
     echo "FAILED to copy a Procfile" | indent
@@ -23,3 +23,10 @@ if ! [ $? ]; then
 fi
 
 echo "Copied ${PROCFILE} as Procfile successfully" | indent
+
+APP_DIR=$(dirname "${BUILD_DIR}/${PROCFILE}")
+
+if [[ -f "${APP_DIR}/app.json" ]]; then
+    cp "${APP_DIR}/app.json" "${BUILD_DIR}/app.json"
+    echo "Copied ${APP_DIR}/app.json as app.json successfully" | indent
+fi


### PR DESCRIPTION
This buildpack is epic for managing a monorepo so thanks heaps for this! 🙂

Currently, there isn't a similar solution for `app.json` files so we are just performing a similar copy in the `heroku-postbuild` step. This pull request implements the functionality to copy an adjacent `app.json` file if one exists. I also double quoted variables (for safety and consistency) and increased indentation by a space as it didn't align with the rest of the output from a Heroku build.