### PR TITLE
Switch example to use buildpack registry URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ _tl;dr_ -- The idea here is that you have a single git repository, but multiple 
 ```
 $ heroku create -a example-1
 $ heroku create -a example-2
-$ heroku buildpacks:add -a example-1 https://github.com/heroku/heroku-buildpack-multi-procfile
-$ heroku buildpacks:add -a example-2 https://github.com/heroku/heroku-buildpack-multi-procfile
+$ heroku buildpacks:add -a example-1 heroku-community/multi-procfile
+$ heroku buildpacks:add -a example-2 heroku-community/multi-procfile
 $ heroku config:set -a example-1 PROCFILE=Procfile
 $ heroku config:set -a example-2 PROCFILE=backend/Procfile
 $ git push https://git.heroku.com/example-1.git HEAD:master
@@ -15,10 +15,10 @@ $ git push https://git.heroku.com/example-2.git HEAD:master
 
 When example-1 builds, it'll copy Procfile into /app/Procfile, and when example-2 builds, it'll copy backend/Procfile to /app/Procfile. For example-2, the process types available for you to scale up will be the ones referenced (originally) in backend/Procfile.
 
-# Pipelines
+## Pipelines
 
 Only **builds** will set the proper Procfile. If you use [Heroku Pipelines](https://devcenter.heroku.com/articles/pipelines), then promoting a slug downstream will not trigger a build, and therefore will not look at the environment variable and act accordingly. Make sure that the proper Procfile is referenced all the way upstream to the first stage that builds.
 
-# Authors
+## Authors
 
 Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com>


### PR DESCRIPTION
Now that the buildpack registry version is up to date (#15).