### PR TITLE
Allow a directory to a Procfile to be specified

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,11 @@ if [[ -z "${PROCFILE}" ]]; then
     exit 1
 fi
 
+if [ -d "${PROCFILE}" ] ; then
+    echo "$PROCFILE is a directory, using: $PROCFILE/Procfile";
+    PROCFILE=$("$PROCFILE/Procfile")
+fi
+
 cp "${BUILD_DIR}/${PROCFILE}" "${BUILD_DIR}/Procfile"
 
 if ! [ $? ]; then


### PR DESCRIPTION
I was encountering an issue where a deploy would proceed silently if a directory was provided as a `PROCFILE` arg.
This is because `cp` does not exit with an error code in this scenario.
This change appends `Procfile` to the path if it is a directory.