### PR TITLE
Add option for appending to Procfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ $ git push https://git.heroku.com/example-2.git HEAD:master
 
 When example-1 builds, it'll copy Procfile into /app/Procfile, and when example-2 builds, it'll copy backend/Procfile to /app/Procfile. For example-2, the process types available for you to scale up will be the ones referenced (originally) in backend/Procfile.
 
+## Appending partial `Procfile`s
+
+One or more files may be appended to the `Procfile` by defining them in a comma separated list
+in the `PROCFILE_APPEND` environment variable.
+
+```bash
+PROCFILE_APPEND=Procfile_a,Procfile_b
+```
+
 ## Pipelines
 
 Only **builds** will set the proper Procfile. If you use [Heroku Pipelines](https://devcenter.heroku.com/articles/pipelines), then promoting a slug downstream will not trigger a build, and therefore will not look at the environment variable and act accordingly. Make sure that the proper Procfile is referenced all the way upstream to the first stage that builds.

--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,21 @@ fi
 
 echo "Copied ${PROCFILE} as Procfile successfully" | indent
 
+PROCFILE_APPEND=$(cat "${ENV_DIR}/PROCFILE_APPEND")
+
+for procfile_addition in ${PROCFILE_APPEND//,/ }
+do
+    if [[ ! -f "${BUILD_DIR}/${procfile_addition}" ]]; then
+        echo "FAILED to locate file: ${procfile_addition}" | indent
+        exit 1
+    fi
+
+    printf "\n# Contents of ${procfile_addition} appended below:\n" >> "${BUILD_DIR}/Procfile"
+    cat "${BUILD_DIR}/${procfile_addition}" >> "${BUILD_DIR}/Procfile"
+
+    echo "Appended contents of ${procfile_addition} to Procfile" | indent
+done
+
 APP_DIR=$(dirname "${BUILD_DIR}/${PROCFILE}")
 
 if [[ -f "${APP_DIR}/app.json" ]]; then


### PR DESCRIPTION
This feature allows us to compose the `Procfile` from multiple files.

## Appending partial `Procfile`s

One or more files may be appended to the `Procfile` by defining them in a comma separated list
in the `PROCFILE_APPEND` environment variable.

```bash
PROCFILE_APPEND=Procfile_a,Procfile_b
```