### PR TITLE
fix: Do nothing and exit when the file doesn't exist

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,13 +15,15 @@ if [[ -z "${PROCFILE}" ]]; then
     exit 1
 fi
 
-cp "${BUILD_DIR}/${PROCFILE}" "${BUILD_DIR}/Procfile"
+PROCFILE_BUILDED="${BUILD_DIR}/${PROCFILE}"
 
-if ! [ $? ]; then
+if [ ! -f "${PROCFILE_BUILDED}" ]; then
     echo "FAILED to copy a Procfile" | indent
+    echo "The file ${PROCFILE_BUILDED} doesn't not exists" | indent
     exit 1
 fi
 
+cp "${PROCFILE_BUILDED}" "${BUILD_DIR}/Procfile"
 echo "Copied ${PROCFILE} as Procfile successfully" | indent
 
 APP_DIR=$(dirname "${BUILD_DIR}/${PROCFILE}")

--- a/bin/compile
+++ b/bin/compile
@@ -16,14 +16,14 @@ if [[ -z "${PROCFILE}" ]]; then
 fi
 
 PROCFILE_BUILDED="${BUILD_DIR}/${PROCFILE}"
+cp "${PROCFILE_BUILDED}" "${BUILD_DIR}/Procfile"
 
-if [ ! -f "${PROCFILE_BUILDED}" ]; then
+if [ $? -ne 0 ]; then
     echo "FAILED to copy a Procfile" | indent
     echo "The file ${PROCFILE_BUILDED} doesn't not exists" | indent
     exit 1
 fi
 
-cp "${PROCFILE_BUILDED}" "${BUILD_DIR}/Procfile"
 echo "Copied ${PROCFILE} as Procfile successfully" | indent
 
 APP_DIR=$(dirname "${BUILD_DIR}/${PROCFILE}")

--- a/bin/compile
+++ b/bin/compile
@@ -15,12 +15,10 @@ if [[ -z "${PROCFILE}" ]]; then
     exit 1
 fi
 
-PROCFILE_BUILDED="${BUILD_DIR}/${PROCFILE}"
-cp "${PROCFILE_BUILDED}" "${BUILD_DIR}/Procfile"
+cp "${BUILD_DIR}/${PROCFILE}" "${BUILD_DIR}/Procfile"
 
 if [ $? -ne 0 ]; then
     echo "FAILED to copy a Procfile" | indent
-    echo "The file ${PROCFILE_BUILDED} doesn't not exists" | indent
     exit 1
 fi
 


### PR DESCRIPTION
I'm using this buildpack to deploy a monorepo at Heroku. After some restructurations, I missed configurations of PROCFILE environment variable and it was pointing to an unknown file. I expected to receive an error when trying to deploy the project, but, the deployment has been made and the application started failing.

I checked the conditional to identify if the Procfile exists or not and made some changes to work appropriately.

Now before trying to copy the file the script will check if the file exists to follow with copy attempt.